### PR TITLE
Add `users` migration and initial seeder

### DIFF
--- a/backend/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/backend/database/migrations/2014_10_12_000000_create_users_table.php
@@ -17,6 +17,7 @@ return new class extends Migration
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
+            $table->enum('role', ['user', 'admin'])->default('user'); // Nuevo campo agregado
             $table->rememberToken();
             $table->timestamps();
         });

--- a/backend/database/seeders/UserSeeder.php
+++ b/backend/database/seeders/UserSeeder.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        DB::table('users')->insert([
+            [
+                'name' => 'Admin User',
+                'email' => 'admin@example.com',
+                'password' => Hash::make('password'),
+                'role' => 'admin',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+            [
+                'name' => 'Regular User',
+                'email' => 'user@example.com',
+                'password' => Hash::make('password'),
+                'role' => 'user',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ],
+        ]);
+    }
+}


### PR DESCRIPTION
📌 **Summary of Changes:**  
This PR adds the migration for the `users` table and an initial seeder with test users (admin and regular user).  

📌 **Included Changes:**  
- **Migration:** `users` table with fields `id`, `name`, `email`, `password`, `role`, `timestamps`.  
- **Seeder:** `UserSeeder.php` to populate the database with test users.  
- **Successfully executed `php artisan migrate`** in MySQL within the Docker container.  
- **Testing performed:**  
  - Verified table creation using `SELECT * FROM users;`.  
  - Used `php artisan tinker` to retrieve users (`\App\Models\User::all();`).  

📌 **Project Impact:**  
- This migration sets up user authentication for upcoming features.  
- The admin user creation facilitates the development of administrative modules in future sprints.  

📌 **Next Steps:**  
✅ Once merged, we will proceed with implementing the **`/api/register` endpoint** in Laravel.  
