### PR TITLE
Add protected /dashboard with logout functionality

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,12 +2,16 @@ import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 import Register from './pages/Register';
 import Login from './pages/Login';
+import Dashboard from './pages/Dashboard';
+import PrivateRoute from './components/PrivateRoute';
 
 const App: React.FC = () => {
   return (
     <Routes>
       <Route path="/register" element={<Register />} />
       <Route path="/login" element={<Login />} />
+
+      <Route path="/dashboard" element={<PrivateRoute><Dashboard /></PrivateRoute>} />
     </Routes>
   );
 };

--- a/frontend/src/components/PrivateRoute.tsx
+++ b/frontend/src/components/PrivateRoute.tsx
@@ -1,0 +1,14 @@
+import React, { ReactElement } from 'react';
+import { Navigate } from 'react-router-dom';
+
+interface PrivateRouteProps {
+  children: ReactElement;
+}
+
+const PrivateRoute = ({ children }: PrivateRouteProps): ReactElement => {
+  const token = localStorage.getItem('token');
+
+  return token ? children : <Navigate to="/login" replace />;
+};
+
+export default PrivateRoute;

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import '../styles/Dashboard.css';
+
+const Dashboard: React.FC = () => {
+  const navigate = useNavigate();
+
+  const handleLogout = async () => {
+    const token = localStorage.getItem('token');
+
+    if (!token) {
+      navigate('/login');
+      return;
+    }
+
+    try {
+      await fetch('http://localhost/api/logout', {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      // Remove token and redirect to login
+      localStorage.removeItem('token');
+      navigate('/login');
+    } catch (error) {
+      console.error('Logout failed', error);
+    }
+  };
+
+  return (
+    <div className="dashboard-container">
+      <h2>Welcome to the Dashboard!</h2>
+      <p>You are successfully logged in.</p>
+      <button onClick={handleLogout}>Logout</button>
+    </div>
+  );
+};
+
+export default Dashboard;

--- a/frontend/src/styles/Dashboard.css
+++ b/frontend/src/styles/Dashboard.css
@@ -1,0 +1,13 @@
+.dashboard-container {
+    text-align: center;
+    margin-top: 50px;
+  }
+  
+  .dashboard-container button {
+    background-color: red;
+    color: white;
+    padding: 10px 20px;
+    border: none;
+    cursor: pointer;
+  }
+  


### PR DESCRIPTION
### 📌 Summary  
This PR adds a **protected dashboard** and **logout functionality** to the frontend.  

### ✅ Features Implemented  
✅ Users are redirected to `/dashboard` after login/register.  
✅ `/dashboard` is **protected**—users without a token are redirected to `/login`.  
✅ Implemented **logout functionality**:
   - Calls `POST /api/logout` to revoke the token.
   - Removes the token from `localStorage`.
   - Redirects user to `/login`.

### 🛠 How to Test  
1️⃣ Login and verify you are redirected to `/dashboard`.  
2️⃣ Check that **unauthorized access to `/dashboard` redirects to `/login`**.  
3️⃣ Click **Logout** and confirm:
   - Token is removed from `localStorage`.
   - User is redirected to `/login`.  
4️⃣ Try to access `/dashboard` again—it should redirect back to `/login`.  
